### PR TITLE
feat: Add label wrapper API to `Item` (`labelTag`, `labelClass`, `labelAttributes`, `labelSetAttribute`, `labelRemoveAttribute`) to wrap the menu-item label in a configurable element; defaults to plain text for backward compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.2.1 Under development
 
+- feat: Add label wrapper API to `Item` (`labelTag`, `labelClass`, `labelAttributes`, `labelSetAttribute`, `labelRemoveAttribute`) to wrap the menu-item label in a configurable element; defaults to plain text for backward compatibility.
+
 ## 0.2.0 May 24, 2026
 
 - refactor!: PHP 8.3 baseline, components and cookbooks migrated to `DefaultsProviderInterface`/`ThemeProviderInterface`, full PHPDoc across `src/`.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,34 @@ echo NavBar::tag()
     ->render();
 ```
 
+#### Menu with wrapped labels
+
+Each item label can be wrapped in its own element (for styling or truncation) via `labelTag`/`labelClass`. Without `labelTag`, the label renders as plain text.
+
+```php
+use UIAwesome\Html\Core\Component\{Item, Menu};
+use UIAwesome\Html\Interop\Inline;
+
+echo Menu::tag()
+    ->type('nav')
+    ->linkClass('nav-link')
+    ->linkActiveClass('is-active')
+    ->items(
+        Item::tag()
+            ->label('Request')
+            ->link('/request')
+            ->active()
+            ->labelTag(Inline::SPAN)
+            ->labelClass('nav-link-label'),
+        Item::tag()
+            ->label('Logs')
+            ->link('/logs')
+            ->labelTag(Inline::SPAN)
+            ->labelClass('nav-link-label'),
+    )
+    ->render();
+```
+
 ### Cookbooks (Bootstrap5, Flowbite)
 
 The core ships preconfigured cookbooks for popular CSS frameworks under `src/Cookbook/`. Each cookbook implements one of the provider interfaces shipped by `ui-awesome/html-core`:

--- a/src/Attribute/HasLabelCollection.php
+++ b/src/Attribute/HasLabelCollection.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Component\Attribute;
+
+use BackedEnum;
+use InvalidArgumentException;
+use Stringable;
+use UIAwesome\Html\Core\Html;
+use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
+use UIAwesome\Html\Interop\{Block, Inline};
+use UnitEnum;
+
+use function is_string;
+
+/**
+ * Provides an immutable API for wrapping a menu-item label in a configurable element.
+ *
+ * Stores the wrapper tag and its HTML attributes. Consumed by {@see \UIAwesome\Html\Core\Component\Item} to wrap the
+ * label text in an optional element (for example a `<span>` or `<div>`). When {@see $labelTag} is `false`, the label
+ * renders as plain text.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasLabelCollection
+{
+    /**
+     * @var mixed[] HTML attributes applied to the label element.
+     */
+    protected array $labelAttributes = [];
+    /**
+     * Label wrapper tag enum, or `false` to render the label as plain text.
+     */
+    protected BackedEnum|false $labelTag = false;
+
+    /**
+     * Returns the value of a single label attribute, or the default when missing.
+     *
+     * Usage example:
+     * ```php
+     * $component->getLabelAttribute('title', 'Menu item');
+     * $component->getLabelAttribute('hidden', null, 'aria-');
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name.
+     * @param mixed $default Default value when the attribute is missing.
+     * @param string $prefix Optional prefix to ensure on the key.
+     *
+     * @return mixed Attribute value or default.
+     */
+    public function getLabelAttribute(string|UnitEnum $key, mixed $default = null, string $prefix = ''): mixed
+    {
+        return AttributeBag::get($this->labelAttributes, $key, $default, $prefix);
+    }
+
+    /**
+     * Returns the label attributes.
+     *
+     * Usage example:
+     * ```php
+     * $component->getLabelAttributes();
+     * ```
+     *
+     * @return mixed[] Current label attributes.
+     */
+    public function getLabelAttributes(): array
+    {
+        return $this->labelAttributes;
+    }
+
+    /**
+     * Sets the label attributes (merged with previous values).
+     *
+     * Usage example:
+     * ```php
+     * $component->labelAttributes(['title' => 'Menu item']);
+     * ```
+     *
+     * @param mixed[] $values Attribute map merged into existing label attributes.
+     *
+     * @return static New instance with the updated `labelAttributes`.
+     */
+    public function labelAttributes(array $values): static
+    {
+        $new = clone $this;
+
+        $new->labelAttributes = [...$this->labelAttributes, ...$values];
+
+        return $new;
+    }
+
+    /**
+     * Adds a CSS class to the label attributes.
+     *
+     * Usage example:
+     * ```php
+     * $component->labelClass('nav-label');
+     * $component->labelClass(['nav-label', 'truncate']);
+     * $component->labelClass(Theme::PRIMARY);
+     * $component->labelClass('nav-label', true);
+     * ```
+     *
+     * @param array<string|Stringable|UnitEnum>|string|Stringable|UnitEnum $value CSS class (or class list) to add.
+     * @param bool $override Whether to replace existing classes (`true`) or merge (`false`).
+     *
+     * @return static New instance with the updated label `class` attribute.
+     */
+    public function labelClass(array|string|Stringable|UnitEnum $value, bool $override = false): static
+    {
+        $new = clone $this;
+
+        CSSClass::add($new->labelAttributes, $value, $override);
+
+        return $new;
+    }
+
+    /**
+     * Removes a single label attribute.
+     *
+     * Usage example:
+     * ```php
+     * $component->labelRemoveAttribute('title');
+     * $component->labelRemoveAttribute('hidden', 'aria-');
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name to remove.
+     * @param string $prefix Optional prefix to ensure on the key.
+     *
+     * @return static New instance without the specified label attribute.
+     */
+    public function labelRemoveAttribute(string|UnitEnum $key, string $prefix = ''): static
+    {
+        $new = clone $this;
+
+        AttributeBag::remove($new->labelAttributes, $key, $prefix);
+
+        return $new;
+    }
+
+    /**
+     * Sets a single label attribute.
+     *
+     * Usage example:
+     * ```php
+     * $component->labelSetAttribute('title', 'Menu item');
+     * $component->labelSetAttribute('hidden', 'true', 'aria-');
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name.
+     * @param mixed $value Attribute value.
+     * @param string $prefix Optional prefix to ensure on the key.
+     *
+     * @return static New instance with the updated label attribute.
+     */
+    public function labelSetAttribute(string|UnitEnum $key, mixed $value, string $prefix = ''): static
+    {
+        $new = clone $this;
+
+        AttributeBag::set($new->labelAttributes, $key, $value, $prefix);
+
+        return $new;
+    }
+
+    /**
+     * Sets the label wrapper tag, or `false` to render the label as plain text.
+     *
+     * Usage example:
+     * ```php
+     * $component->labelTag();
+     * $component->labelTag(\UIAwesome\Html\Interop\Inline::SPAN);
+     * $component->labelTag('div');
+     * $component->labelTag(false);
+     * ```
+     *
+     * @param BackedEnum|false|string $value Inline/Block enum case (recommended) or its tag name, or `false` to render
+     * the label as plain text.
+     *
+     * @throws InvalidArgumentException When the string value does not resolve to an {@see Inline} or {@see Block}
+     * enum case.
+     *
+     * @return static New instance with the updated `labelTag`.
+     */
+    public function labelTag(BackedEnum|false|string $value = Inline::SPAN): static
+    {
+        if (is_string($value)) {
+            $value = self::resolveLabelTag($value);
+        }
+
+        $new = clone $this;
+
+        $new->labelTag = $value;
+
+        return $new;
+    }
+
+    /**
+     * Renders the label, wrapping it with the configured tag, or returns it as plain text when {@see $labelTag} is
+     * `false` or the label is empty.
+     *
+     * @param string $label Label text to render.
+     *
+     * @return string Wrapped label when a tag is set and the label is not empty, or the plain label otherwise.
+     */
+    protected function renderLabel(string $label): string
+    {
+        if ($this->labelTag === false || $label === '') {
+            return $label;
+        }
+
+        return Html::element($this->labelTag, $label, $this->labelAttributes);
+    }
+
+    /**
+     * Resolves a string tag name against {@see Inline} and {@see Block} enums in order, throwing when neither
+     * recognizes the value.
+     *
+     * @param string $name Tag name to resolve.
+     *
+     * @throws InvalidArgumentException When the value does not match any {@see Inline} or {@see Block} case.
+     *
+     * @return BackedEnum Matching enum case.
+     */
+    private static function resolveLabelTag(string $name): BackedEnum
+    {
+        $tag = Inline::tryFrom($name);
+
+        if ($tag !== null) {
+            return $tag;
+        }
+
+        $tag = Block::tryFrom($name);
+
+        if ($tag !== null) {
+            return $tag;
+        }
+
+        throw new InvalidArgumentException(
+            "Label tag '{$name}' must resolve to an `Inline` or `Block` enum case.",
+        );
+    }
+}

--- a/src/Item.php
+++ b/src/Item.php
@@ -9,6 +9,7 @@ use Stringable;
 use UIAwesome\Html\Contracts\RenderableInterface;
 use UIAwesome\Html\Core\Component\Attribute\{
     HasIconCollection,
+    HasLabelCollection,
     HasLinkCollection,
     HasLinkContainerCollection,
     HasListItemCollection,
@@ -44,6 +45,7 @@ class Item extends BaseBlock implements RenderableInterface
     use HasContent;
     use HasCurrentPath;
     use HasIconCollection;
+    use HasLabelCollection;
     use HasLinkCollection;
     use HasLinkContainerCollection;
     use HasListItemCollection;
@@ -392,7 +394,7 @@ class Item extends BaseBlock implements RenderableInterface
             [
                 '{content}' => $this->getContent(),
                 '{icon}' => $this->renderIcon(),
-                '{label}' => $this->label,
+                '{label}' => $this->renderLabel($this->label),
             ],
         );
 

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Core\Component\Item;
-use UIAwesome\Html\Core\Component\Tests\Support\RenderIconOverride;
+use UIAwesome\Html\Core\Component\Tests\Support\{RenderIconOverride, RenderLabelOverride};
 
 /**
  * Unit tests for the {@see Item} component rendering and immutable configuration.
@@ -357,6 +357,202 @@ final class ItemTest extends TestCase
         );
     }
 
+    public function testLabelAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <span title="tip">
+            value
+            </span>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelAttributes(['title' => 'tip'])
+                ->labelTag()
+                ->link('/')
+                ->render(),
+            'Label attribute map must decorate the label element.',
+        );
+    }
+
+    public function testLabelAttributesMergesAcrossCalls(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <span class="first" title="tip">
+            value
+            </span>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelAttributes(['class' => 'first'])
+                ->labelAttributes(['title' => 'tip'])
+                ->labelTag()
+                ->link('/')
+                ->render(),
+            'Prior values must be retained on merge.',
+        );
+    }
+
+    public function testLabelClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <span class="nav-label">
+            value
+            </span>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelClass('nav-label')
+                ->labelTag()
+                ->link('/')
+                ->render(),
+            'CSS class must be applied to the label element.',
+        );
+    }
+
+    public function testLabelClassMergesWithBaseLabelAttributeClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <span class="base value">
+            label
+            </span>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('label')
+                ->labelAttributes(['class' => 'base'])
+                ->labelClass('value')
+                ->labelTag()
+                ->link('/')
+                ->render(),
+            "Default 'labelClass' merge must append to existing label class.",
+        );
+    }
+
+    public function testLabelRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <span>
+            value
+            </span>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelAttributes(['title' => 'tip'])
+                ->labelRemoveAttribute('title')
+                ->labelTag()
+                ->link('/')
+                ->render(),
+            'Removed label attribute must not appear in the rendered label element.',
+        );
+    }
+
+    public function testLabelSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <span title="tip">
+            value
+            </span>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelSetAttribute('title', 'tip')
+                ->labelTag()
+                ->link('/')
+                ->render(),
+            'Set label attribute must appear on the rendered label element.',
+        );
+    }
+
+    public function testLabelTag(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <span>
+            value
+            </span>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelTag()
+                ->link('/')
+                ->render(),
+            "Default label tag must be '<span>'.",
+        );
+    }
+
+    public function testLabelTagWithFalseValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            value
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelTag(false)
+                ->link('/')
+                ->render(),
+            "'false' label tag must render the label as plain text.",
+        );
+    }
+
+    public function testLabelTagWithValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <li>
+            <a href="/">
+            <div>
+            value
+            </div>
+            </a>
+            </li>
+            HTML,
+            Item::tag()
+                ->label('value')
+                ->labelTag('div')
+                ->link('/')
+                ->render(),
+            'Custom label tag must wrap the label.',
+        );
+    }
+
     public function testLabelWithEncodeFalse(): void
     {
         self::assertSame(
@@ -658,6 +854,15 @@ final class ItemTest extends TestCase
         );
     }
 
+    public function testRenderLabelRemainsProtectedForSubclassOverride(): void
+    {
+        self::assertInstanceOf(
+            Item::class,
+            new RenderLabelOverride(),
+            'Override subclass must be an `Item` instance.',
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingAttribute(): void
     {
         $instance = Item::tag();
@@ -730,6 +935,31 @@ final class ItemTest extends TestCase
         self::assertNotSame(
             $instance,
             $instance->label(''),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->labelAttributes([]),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->labelClass(''),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->labelRemoveAttribute('key'),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->labelSetAttribute('key', 'value'),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->labelTag(false),
             'New instance must be returned (immutability).',
         );
         self::assertNotSame(
@@ -899,6 +1129,16 @@ final class ItemTest extends TestCase
         );
 
         Item::tag()->iconTag('div');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenLabelTagDoesNotResolveToEnum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Label tag 'my-label' must resolve to an `Inline` or `Block` enum case.",
+        );
+
+        Item::tag()->labelTag('my-label');
     }
 
     public function testThrowInvalidArgumentExceptionWhenLinkContainerTagDoesNotResolveToEnum(): void

--- a/tests/Support/RenderLabelOverride.php
+++ b/tests/Support/RenderLabelOverride.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Core\Component\Tests\Support;
+
+use Override;
+use UIAwesome\Html\Core\Component\Item;
+
+/**
+ * Subclass that overrides {@see \UIAwesome\Html\Core\Component\Attribute\HasLabelCollection::renderLabel()} with PHP's
+ * `#[Override]` attribute.
+ *
+ * Loading the class fails fatally when the parent method is not inheritable (for example, when a mutation flips the
+ * trait method visibility from `protected` to `private`), which makes any test instantiating it detect the
+ * {@see https://infection.github.io/guide/mutators.html#ProtectedVisibility} mutator.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class RenderLabelOverride extends Item
+{
+    #[Override]
+    protected function renderLabel(string $label): string
+    {
+        return parent::renderLabel($label);
+    }
+}


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
